### PR TITLE
ItemData hashcode implementation

### DIFF
--- a/hashtag-view/src/main/java/com/greenfrvr/hashtagview/ItemData.java
+++ b/hashtag-view/src/main/java/com/greenfrvr/hashtagview/ItemData.java
@@ -52,6 +52,11 @@ class ItemData<T> implements Comparable<ItemData> {
     }
 
     @Override
+    public int hashCode() {
+        return data.hashCode();
+    }
+
+    @Override
     public String toString() {
         return String.format("Item data: title - %s, width - %f", data.toString(), width);
     }


### PR DESCRIPTION
According to the [docs](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#equals%28java.lang.Object%29):

> Note that it is generally necessary to override the hashCode method whenever this method is overridden, so as to maintain the general contract for the hashCode method, which states that equal objects must have equal hash codes.
